### PR TITLE
Fix Figma plugin Symbol serialization and MCP server port conflict

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,13 +22,8 @@ export async function startServer(): Promise<void> {
   });
 
   if (isStdioMode) {
-    // In STDIO mode, also start HTTP server for plugin integration
-    console.error(`Initializing Figma MCP Server in STDIO mode with plugin integration on port ${config.port}...`);
-
-    // Start HTTP server for plugin endpoints (non-blocking)
-    startHttpServer(config.port, server).catch((error) => {
-      console.error("Failed to start HTTP server for plugin integration:", error);
-    });
+    // In STDIO mode, only connect via stdio transport
+    console.error(`Initializing Figma MCP Server in STDIO mode...`);
 
     // Connect STDIO transport for MCP communication
     const transport = new StdioServerTransport();


### PR DESCRIPTION
- Fix "cannot unwrap symbol" error in Figma plugin by improving serialization
  - Enhanced sanitizeForSerialization to properly handle Symbol, BigInt, Date, and RegExp types
  - Added proper error handling for selection changes
  - Sanitize data before all postMessage calls to prevent serialization errors

- Fix MCP server port 3333 conflict in stdio mode
  - Remove automatic HTTP server startup when running in stdio mode
  - Keep stdio mode purely for MCP communication via stdin/stdout
  - HTTP server now only starts in explicit HTTP mode

🤖 Generated with [Claude Code](https://claude.ai/code)